### PR TITLE
2.61 - option (d) - fix

### DIFF
--- a/Solution/Chapter 2/S2HP_2.61.c
+++ b/Solution/Chapter 2/S2HP_2.61.c
@@ -38,36 +38,34 @@ int test_option_c(int x)
 }
 
 int test_option_d(int x) {
-    /*
-        if sizeof(int) == 4
-        
-        4 - 1 = 3
-        3 << 3
-        
-        011 << 3 = 011000
-        011000 = 16 + 8 = 24 (32 - 8)
-        
-        x >> 24
-    */
-    int shift_val = (sizeof(int) - 1) << 3;
+        /*
+                if sizeof(int) == 4
+
+                4 - 1 = 3
+                3 << 3
+
+                011 << 3 = 011000
+                011000 = 16 + 8 = 24 (32 - 8)
+        */
+        int shift_val = (sizeof(int) - 1) << 3;
     
-    /*
-        E.x: 32bit representation
+        /*
+                E.x: 32bit representation
+
+                int 5
+                0000 0000 0000 0000 0000 0000 0000 0101 >> 24
+                We get the last byte (eight bits) = 0000 0000
+
+                0000 0000 & 1111 1111 = 0000 0000
+
+                int -5
+                1111 1111 1111 1111 1111 1111 1111 1011  >> 24
+                We get the last byte (eight bits) = 1111 1111
+
+                1111 1111 & 1111 1111 = 1111 1111
+        */
         
-        int 5
-        0000 0000 0000 0000 0000 0000 0000 0101 >> 24
-        We get the last byte (eight bits) = 0000 0000
-        
-        0000 0000 & 1111 1111 = 0000 0000
-        
-        int -5
-        1111 1111 1111 1111 1111 1111 1111 1011  >> 24
-        We get the last byte (eight bits) = 1111 1111
-        
-         1111 1111 & 1111 1111 = 1111 1111
-    */
-    
-    return !(x >> shift_val);
+        return !(x >> shift_val);
 }
 
 int main(void)

--- a/Solution/Chapter 2/S2HP_2.61.c
+++ b/Solution/Chapter 2/S2HP_2.61.c
@@ -37,9 +37,37 @@ int test_option_c(int x)
         return !!(x & 0xFF);
 }
 
-int test_option_d(int x)
-{
-        return !!(~x & 0xFF);
+int test_option_d(int x) {
+    /*
+        if sizeof(int) == 4
+        
+        4 - 1 = 3
+        3 << 3
+        
+        011 << 3 = 011000
+        011000 = 16 + 8 = 24 (32 - 8)
+        
+        x >> 24
+    */
+    int shift_val = (sizeof(int) - 1) << 3;
+    
+    /*
+        E.x: 32bit representation
+        
+        int 5
+        0000 0000 0000 0000 0000 0000 0000 0101 >> 24
+        We get the last byte (eight bits) = 0000 0000
+        
+        0000 0000 & 1111 1111 = 0000 0000
+        
+        int -5
+        1111 1111 1111 1111 1111 1111 1111 1011  >> 24
+        We get the last byte (eight bits) = 1111 1111
+        
+         1111 1111 & 1111 1111 = 1111 1111
+    */
+    
+    return !(x >> shift_val);
 }
 
 int main(void)


### PR DESCRIPTION
It does return `1` when the most significant byte is `1`, which I think it should return `0` and only if most significant byte is `0` it should return `1`.

I've made some comments that explains how it works by example.